### PR TITLE
feat: auto_headroom_percentage config in main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,7 @@ resource "spotinst_ocean_ecs" "ocean_ecs" {
     autoscaler {
         is_enabled                      = var.autoscaler_is_enabled
         is_auto_config                  = var.autoscaler_is_auto_config
+        auto_headroom_percentage        = var.auto_headroom_percentage
         cooldown                        = var.cooldown
         headroom {
             cpu_per_unit                = var.cpu_per_unit


### PR DESCRIPTION
`auto_headroom_percentage` variable is set, but config in `main.tf` is not using the parameter.